### PR TITLE
Deployment Improvements + Sign-out Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "db:schema": "prisma migrate dev && prisma generate",
     "seed": "yarn prisma db seed",
     "prepare": "husky install",
-    "test": "jest"
+    "test": "jest",
+    "vercel-build": "prisma generate && prisma db push && next build"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mapbox-gl": "^2.9.1",
     "material-ui": "^0.20.2",
     "next": "^12.2.4",
-    "next-auth": "^4.10.3",
+    "next-auth": "4.17.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.32.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4068,10 +4068,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-next-auth@^4.10.3:
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/next-auth/-/next-auth-4.18.0.tgz#f6fb4d2a1bfd6e90650755c13324e24d1f44b0d4"
-  integrity sha512-lqJtusYqUwDiwzO4+B+lx/vKCuf/akcdhxT5R47JmS5gvI9O6Y4CZYc8coysY7XaMGHCxfttvTSEw76RA8gNTg==
+next-auth@4.17.0:
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/next-auth/-/next-auth-4.17.0.tgz#776d2a0999d4e2eb56968cad282c1ecd37516a2c"
+  integrity sha512-aN2tdnjS0MDeUpB2tBDOaWnegkgeMWrsccujbXRGMJ607b+EwRcy63MFGSr0OAboDJEe0902piXQkt94GqF8Qw==
   dependencies:
     "@babel/runtime" "^7.16.3"
     "@panva/hkdf" "^1.0.1"


### PR DESCRIPTION
### Notes 
1. Change ``next-auth`` dependency from a [caret range](https://github.com/npm/node-semver#caret-ranges-123-025-004) to a plain version (4.17.0). Before, the caret range evaluated to 4.18.0 (see [yarn.lock](https://github.com/sandboxnu/nucarpool/blob/main/yarn.lock#L4072)), which for some reason breaks sign-out. 
2. Add ``vercel-build`` script to ``package.json``, so that whenever Vercel deploys, we regenerate the Prisma client and update the PS database. We use ``db push`` instead of ``prisma migrate ...`` because of [this](https://planetscale.com/docs/tutorials/automatic-prisma-migrations). For this to work, I did some Vercel/PS setup so we have two separate databases, one for Production and one for the Preview release. This is required so that pushing to a non-main branch doesn't override the main database.  

### Testing
1. ``yarn dev`` for sign-out fix.
2. Tested the Vercel deployment logic on my personal stack (Vercel/PS/OAuth). 
3. Tested on [our Vercel deployment](https://nucarpool-46y7-3i8hy8lrv-sandboxneu.vercel.app/).

### Issues
1. [epc4POfd](https://trello.com/c/epc4POfd)