### PR TITLE
Hotfix for Favorites Button Issue

### DIFF
--- a/src/components/ExploreSidebar.tsx
+++ b/src/components/ExploreSidebar.tsx
@@ -26,6 +26,9 @@ interface ExploreSidebarProps {
 
 const ExploreSidebar = (props: ExploreSidebarProps) => {
   const [curList, setCurList] = useState<PublicUser[]>(props.reccs ?? []);
+  const [curOption, setCurOption] = useState<"reccomendations" | "favorites">(
+    "reccomendations"
+  );
 
   useEffect(() => {
     setCurList(props.reccs ?? []);
@@ -39,12 +42,13 @@ const ExploreSidebar = (props: ExploreSidebarProps) => {
         <div className="flex justify-center gap-3">
           <button
             className={
-              curList == props.reccs
+              curOption === "reccomendations"
                 ? "bg-northeastern-red rounded-xl p-2 font-semibold text-xl text-white"
                 : "rounded-xl p-2 font-semibold text-xl text-black"
             }
             onClick={() => {
               setCurList(props.reccs ?? []);
+              setCurOption("reccomendations");
               clearMarkers();
             }}
           >
@@ -52,12 +56,13 @@ const ExploreSidebar = (props: ExploreSidebarProps) => {
           </button>
           <button
             className={
-              curList == props.favs
+              curOption === "favorites"
                 ? "bg-northeastern-red rounded-xl p-2 font-semibold text-xl text-white"
                 : "rounded-xl p-2 font-semibold text-xl text-black"
             }
             onClick={() => {
               setCurList(props.favs ?? []);
+              setCurOption("favorites");
               clearMarkers();
             }}
           >

--- a/src/components/RequestSidebar.tsx
+++ b/src/components/RequestSidebar.tsx
@@ -48,7 +48,7 @@ const RequestSidebar = (props: RequestSidebarProps) => {
         <div className="flex justify-center gap-3">
           <button
             className={
-              curList == props.sent
+              handleManage === "sent"
                 ? "bg-sky-900 rounded-xl p-2 font-semibold text-xl text-white"
                 : "rounded-xl p-2 font-semibold text-xl text-black"
             }
@@ -62,7 +62,7 @@ const RequestSidebar = (props: RequestSidebarProps) => {
           </button>
           <button
             className={
-              curList == props.received
+              handleManage === "received"
                 ? "bg-sky-900 rounded-xl p-2 font-semibold text-xl text-white"
                 : "rounded-xl p-2 font-semibold text-xl text-black"
             }


### PR DESCRIPTION
This PR fixes an issue where altering which users you have favorited would change the favorites button to no longer have the selected design to it. This was fixed by representing the current option selected statefully using an enum string rather than checking array equality.