### PR TITLE
Profile Population Fixes

### DIFF
--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -14,8 +14,6 @@ import Radio from "../components/Radio";
 import useSearch from "../utils/search";
 import Checkbox from "@mui/material/Checkbox";
 import DayBox from "../components/DayBox";
-import { Tooltip, Icon } from "@mui/material";
-import { MdHelp } from "react-icons/md";
 import {
   BottomProfileSection,
   CompleteProfileButton,
@@ -357,6 +355,11 @@ const Profile: NextPage = () => {
                           type="number"
                           {...register("seatAvail", { valueAsNumber: true })}
                         />
+                        <Note>
+                          {" "}
+                          Registering 0 available seats will remove you from the
+                          app's recommendaiton generation.
+                        </Note>
                       </div>
                     )}
                   </div>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -357,7 +357,7 @@ const Profile: NextPage = () => {
                         />
                         <Note>
                           Registering 0 available seats will remove you from the
-                          app's recommendaiton generation.
+                          app&apos;s recommendaiton generation.
                         </Note>
                       </div>
                     )}
@@ -439,9 +439,9 @@ const Profile: NextPage = () => {
                   <div className="flex flex-col space-y-2">
                     <div className="flex flex-row items-center">
                       <Note>
-                        If you don't have set times, communicate that on your
-                        own with potential riders/drivers. For start/end time,
-                        enter whatever best matches your work schedule.
+                        If you don&apos;t have set times, communicate that on
+                        your own with potential riders/drivers. For start/end
+                        time, enter whatever best matches your work schedule.
                       </Note>
                     </div>
                   </div>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -356,7 +356,6 @@ const Profile: NextPage = () => {
                           {...register("seatAvail", { valueAsNumber: true })}
                         />
                         <Note>
-                          {" "}
                           Registering 0 available seats will remove you from the
                           app's recommendaiton generation.
                         </Note>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -63,7 +63,8 @@ const onboardSchema = z.intersection(
     seatAvail: z
       .number({ invalid_type_error: "Cannot be empty" })
       .int("Must be an integer")
-      .nonnegative("Must be greater or equal to 0"),
+      .nonnegative("Must be greater or equal to 0")
+      .max(6),
     companyName: z.string().min(1, "Cannot be empty"),
     companyAddress: z.string().min(1, "Cannot be empty"),
     startAddress: z.string().min(1, "Cannot be empty"),
@@ -435,27 +436,11 @@ const Profile: NextPage = () => {
                   </div>
                   <div className="flex flex-col space-y-2">
                     <div className="flex flex-row items-center">
-                      <Checkbox
-                        {...register("timeDiffers")}
-                        sx={{
-                          padding: 0,
-                          input: {
-                            width: 30,
-                            height: 30,
-                          },
-                        }}
-                      />
-                      <LightEntryLabel className="pl-2 pr-3 text-sm ">
-                        My start/end time is different each day
-                      </LightEntryLabel>
-                      <Tooltip
-                        title="If you don't have set times, communicate that on your own with potential riders/drivers."
-                        placement="right"
-                      >
-                        <Icon classes={{ root: "w-48" }} fontSize="medium">
-                          <MdHelp fill="#C8102E" />
-                        </Icon>
-                      </Tooltip>
+                      <Note>
+                        If you don't have set times, communicate that on your
+                        own with potential riders/drivers. For start/end time,
+                        enter whatever best matches your work schedule.
+                      </Note>
                     </div>
                   </div>
                 </CommutingScheduleSection>
@@ -504,7 +489,7 @@ const Profile: NextPage = () => {
                       {...register("bio")}
                     />
                     <Note>
-                      Note: This intro will be shared with people you choose to
+                      This intro will be shared with people you choose to
                       connect with.
                     </Note>
                   </div>


### PR DESCRIPTION
Accomplished: 
1. Max seat number validation on seat availability for riders: 6 seats
2. Removes the checkbox for the "start/end time is different every day" field. Now, we just display a note saying that they should communicate with their carpool group themselves. 
3. Continues to allow entering 0 as a possible number of seats. This is necessary because drivers might need to go back later and edit the number of seats to be 0. What we should do instead is update our recommendations to make sure the number of seats left is > 0. The textbox now has a note that makes this clear. 