### PR TITLE
fixed rec algo

### DIFF
--- a/src/utils/recommendation.ts
+++ b/src/utils/recommendation.ts
@@ -49,7 +49,8 @@ const calculateScore = (
     if (
       (currentUser.role === "RIDER" &&
         (user.role === "RIDER" || user.seatAvail === 0)) ||
-      (currentUser.role === "DRIVER" && user.role === "DRIVER")
+      (currentUser.role === "DRIVER" && user.role === "DRIVER") ||
+      (currentUser.role === "DRIVER" && user.seatAvail === 0)
     ) {
       return undefined;
     }

--- a/src/utils/recommendation.ts
+++ b/src/utils/recommendation.ts
@@ -70,9 +70,20 @@ const calculateScore = (
 
     const userDays = dayConversion(user);
     // get the number of days that both user A AND user B are NOT going in
-    const days = currentUserDays
+    let days = currentUserDays
       .map((day, index) => !(day && userDays[index]))
       .reduce((prev, curr) => (curr ? prev + 1 : prev), 0);
+
+    // if both users are going in all 5 days of the week, then weekend days off should not affect score
+    if (
+      days === 2 &&
+      !currentUserDays[0] &&
+      !currentUserDays[6] &&
+      !userDays[0] &&
+      !userDays[6]
+    ) {
+      days = 0;
+    }
 
     let startTime: number | undefined;
     let endTime: number | undefined;


### PR DESCRIPTION
4 changes were made:

1. Start and end time calculations were incorrect.
- The differences (which could be negative) were first being multiplied and added and then the absolute of the result was being considered
- It should be `(absolute difference of the hours) * 60 + (absolute difference of the minutes)`

2. Final score in the case of an undefined start or end time was incorrect.
- Currently, there is some weird division and multiplication
- In order to fix this, I made the score worse by the maximum weightage of start time and end time (only when times are undefined)

3. The `deprioritizationFactor` was removed because we no longer recommend drivers to drivers.
- I took the factor out all together

5. The mapping of days that the users' schedules don't match was incorrect.
- In theory, we want to count the number of days that at most one user is going in to work (AKA: either or none. both users going in on the same day is a match and should not be counted)
- If this number is greater than 5, (meaning the users only go in on the same day at most once), then we don't want to recommend these users to each other
- I changed the mapping to a NAND operation
- Changed the cutoff for days to 5 to account for weekends too
- If 2 users are going in all 5 days of the week and are not going in on the weekend only, then the `days` would be 2. However, this is actually a perfect match and therefore, I added a condition to make `days = 0` in such a scenario.