### PR TITLE
Inactivity checkbox, Loading screen from profile to map or vice versa, Relocated role selection 

### DIFF
--- a/src/components/DropDownMenu.tsx
+++ b/src/components/DropDownMenu.tsx
@@ -2,17 +2,31 @@ import { Menu, Transition } from "@headlessui/react";
 import { signOut, useSession } from "next-auth/react";
 import Image from "next/image";
 import Link from "next/link";
-import React, { Fragment } from "react";
+import Spinner from "./Spinner";
+import React, { Fragment, useState } from "react";
 import { AiOutlineUser } from "react-icons/ai";
+import { useRouter } from "next/router";
 
 const DropDownMenu = () => {
   const { data: session } = useSession();
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
   const logout = () => {
     signOut();
+  };
+  const handleProfileClick = async () => {
+    setIsLoading(true);
+    await router.push("/profile");
+    setIsLoading(false);
   };
 
   return (
     <div className="z-30">
+      {isLoading && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-white ">
+          <Spinner />
+        </div>
+      )}
       <Menu>
         <Menu.Button className="rounded-full bg-gray-400 p-2">
           <AiOutlineUser className="h-7 w-7" />
@@ -37,11 +51,12 @@ const DropDownMenu = () => {
                 <p className="text-sm font-light text-gray-500">
                   {session.user.email}
                 </p>
-                <Link href="/profile">
-                  <a className="mt-4 w-4/5 rounded-2xl border border-gray-300 bg-white px-3 py-2 text-center hover:bg-gray-100">
-                    Profile
-                  </a>
-                </Link>
+                <button
+                  onClick={handleProfileClick}
+                  className="mt-4 w-4/5 rounded-2xl border border-gray-300 bg-white px-3 py-2 text-center hover:bg-gray-100"
+                >
+                  Profile
+                </button>
                 <Link href="https://docs.google.com/forms/d/e/1FAIpQLSfkbEiOsLIs55fUJgMlDcJ9YkbejTzotjSDXHciSn4tb_z0ug/viewform?usp=sf_link">
                   <a className="mt-4 w-4/5 rounded-2xl border border-gray-300 bg-white px-3 py-2 text-center hover:bg-gray-100">
                     Feedback

--- a/src/components/UserCards/UserCard.tsx
+++ b/src/components/UserCards/UserCard.tsx
@@ -143,7 +143,7 @@ export const UserCard = (props: UserCardProps): JSX.Element => {
         </button>
         <button
           onClick={() => props.rightButton.onPress(props.otherUser)}
-          disabled={user.role === "VIEWER"}
+          disabled={user.role === "VIEWER" || user.status === "INACTIVE"}
           className={getButtonClassName(props.rightButton)}
         >
           {props.rightButton.text}

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -634,11 +634,11 @@ const Profile: NextPage = () => {
                     </Note>
                   </div>
                 </PersonalInfoSection>
+                <CompleteProfileButton type="submit">
+                  Complete Profile
+                </CompleteProfileButton>
               </ProfileColumn>
             </div>
-            <CompleteProfileButton type="submit">
-              Complete Profile
-            </CompleteProfileButton>
           </div>
         </ProfileContainer>
       </div>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -337,7 +337,7 @@ const Profile: NextPage = () => {
                   <ProfileHeaderNoMB>
                     I am a... <span className="text-northeastern-red">*</span>
                   </ProfileHeaderNoMB>
-                  <div className="flex h-24 items-end space-x-4">
+                  <div className="flex h-20 items-end space-x-4">
                     <Radio
                       label="Viewer"
                       id="viewer"

--- a/src/styles/profile.ts
+++ b/src/styles/profile.ts
@@ -15,7 +15,7 @@ export const CompleteProfileButton = styled.button`
   text-align: center;
   color: #ffffff;
   padding: 5px 7px 5px 7px;
-  width: 18%;
+  width: 100%;
   align-self: flex-end;
   @media (min-width: 834px) {
     justify-self: flex-end;
@@ -59,7 +59,7 @@ export const BottomProfileSection = styled(ProfileColumn)`
 
 export const TopProfileSection = styled(ProfileColumn)`
   width: 100%;
-  padding: 1rem 0 1rem 0;
+  padding: 0 0 1rem 0;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;

--- a/src/styles/profile.ts
+++ b/src/styles/profile.ts
@@ -46,18 +46,18 @@ export const ProfileColumn = styled.div`
   gap: 6px;
 `;
 
-export const TopProfileSection = styled(ProfileColumn)`
+export const MiddleProfileSection = styled(ProfileColumn)`
   width: 100%;
   flex: 1 1 auto;
 `;
 
-export const MiddleProfileSection = styled(ProfileColumn)`
+export const BottomProfileSection = styled(ProfileColumn)`
   width: 100%;
   flex: 1 1 auto;
   margin-bottom: 24px;
 `;
 
-export const BottomProfileSection = styled(ProfileColumn)`
+export const TopProfileSection = styled(ProfileColumn)`
   width: 100%;
   padding: 1rem 0 1rem 0;
   display: flex;


### PR DESCRIPTION
Scrum-57, Scrum-33, Scrum-38

Loading screen now displays while waiting for profile page or map/home page to load: 
![image](https://github.com/user-attachments/assets/4fabc25c-1a89-4a0f-80a9-c5b0e0e435cb)

Inactivity checkbox added. Users cannot connect with other users and will not be shown on the map while inactive.
Role selection has been moved up in the signup flow and the tool tip for riders/drivers has been changed as in Scrum-57:
![image](https://github.com/user-attachments/assets/74ae10e7-2f39-49b9-b666-dd4a567025cd)
