### PR TITLE
Enable multiple user connect cards rendered on map click, adjust clustering

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-toastify": "^9.0.4",
     "styled-components": "^5.3.6",
     "superjson": "^1.9.1",
+    "tailwind-scrollbar": "^3.1.0",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/src/components/MapConnectPortal.tsx
+++ b/src/components/MapConnectPortal.tsx
@@ -4,7 +4,7 @@ import { ConnectCard } from "./UserCards/ConnectCard";
 import { Dialog } from "@headlessui/react";
 
 interface ConnectPortalProps {
-  otherUser: PublicUser | null;
+  otherUsers: PublicUser[] | null;
   extendUser: (user: PublicUser) => EnhancedPublicUser;
   onViewRouteClick: (user: User, otherUser: PublicUser) => void;
   onViewRequest: (userId: string) => void;
@@ -14,25 +14,30 @@ interface ConnectPortalProps {
 export const MapConnectPortal = (props: ConnectPortalProps) => {
   return (
     <Dialog
-      open={!!props.otherUser}
+      open={!!(props.otherUsers && props.otherUsers.length > 0)}
       onClose={props.onClose}
       className="relative z-50"
     >
       <div className="fixed inset-0" aria-hidden="true">
-        <div className="fixed inset-0 mt-16 flex items-start justify-end pt-2">
+        <div className="fixed inset-0 mt-20 flex items-start justify-end pt-2">
           <Dialog.Panel>
             <div>
-              <div tabIndex={0} className="w-96">
-                {props.otherUser && (
-                  <ConnectCard
-                    otherUser={props.extendUser(props.otherUser)}
-                    onViewRouteClick={props.onViewRouteClick}
-                    onViewRequest={props.onViewRequest}
-                    onClose={(string) => {
-                      string == "connect" ? props.onClose() : {};
-                    }}
-                  />
-                )}
+              <div
+                tabIndex={0}
+                className="max-h-[calc(100vh-8rem)] w-96 overflow-y-scroll scrollbar-none"
+              >
+                {props.otherUsers &&
+                  props.otherUsers.map((user: PublicUser) => (
+                    <ConnectCard
+                      key={user.id}
+                      otherUser={props.extendUser(user)}
+                      onViewRouteClick={props.onViewRouteClick}
+                      onViewRequest={props.onViewRequest}
+                      onClose={(string) => {
+                        string == "connect" ? props.onClose() : {};
+                      }}
+                    />
+                  ))}
               </div>
             </div>
           </Dialog.Panel>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -83,7 +83,7 @@ const Home: NextPage<any> = () => {
   const [otherUser, setOtherUser] = useState<PublicUser | null>(null);
   const [mapState, setMapState] = useState<mapboxgl.Map>();
   const [sidebarType, setSidebarType] = useState<HeaderOptions>("explore");
-  const [popupUser, setPopupUser] = useState<PublicUser | null>(null);
+  const [popupUsers, setPopupUsers] = useState<PublicUser[] | null>(null);
   const mapContainerRef = useRef(null);
   const [points, setPoints] = useState<[number, number][]>([]);
   const [companyAddressSuggestions, setCompanyAddressSuggestions] = useState<
@@ -254,7 +254,7 @@ const Home: NextPage<any> = () => {
             user.role
           );
         }
-        addMapEvents(newMap, user, setPopupUser);
+        addMapEvents(newMap, user, setPopupUsers);
       });
       setMapState(newMap);
     }
@@ -442,12 +442,12 @@ const Home: NextPage<any> = () => {
                   {user.role === "VIEWER" && viewerBox}
                   <MapLegend role={user.role} />
                   <MapConnectPortal
-                    otherUser={popupUser}
+                    otherUsers={popupUsers}
                     extendUser={extendPublicUser}
                     onViewRouteClick={onViewRouteClick}
                     onViewRequest={handleUserSelect}
                     onClose={() => {
-                      setPopupUser(null);
+                      setPopupUsers(null);
                     }}
                   />
                 </div>

--- a/src/utils/map/addClusters.ts
+++ b/src/utils/map/addClusters.ts
@@ -13,7 +13,7 @@ const addClusters = (map: Map, geoJsonUsers: GeoJsonUsers) => {
     type: "geojson",
     data: geoJsonUsers,
     cluster: true,
-    clusterMaxZoom: 10,
+    clusterMaxZoom: 12,
     clusterRadius: 50,
   });
 
@@ -26,6 +26,8 @@ const addClusters = (map: Map, geoJsonUsers: GeoJsonUsers) => {
       "circle-color": [
         "step",
         ["get", "point_count"],
+        "#66c2a5",
+        2,
         "#51bbd6",
         20,
         "#f1f075",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -31,6 +31,8 @@ module.exports = {
   },
   plugins: [
     require("@tailwindcss/forms"),
+    require("tailwind-scrollbar"),
+
     // ...
   ],
 };


### PR DESCRIPTION
Clustering now continues until 1 level below max zoom. When a stack of user's is clicked, all user cards will popup and be available for interaction. User connect cards are scrollable but the scrollbar is hidden (its very rare we will have > 4 user's stacked on top of each other).
1 lvl below max zoom: 
![image](https://github.com/user-attachments/assets/53b45a0f-9560-4857-b427-386d6ccd55ca)
max zoom: 
![image](https://github.com/user-attachments/assets/13523728-620d-4726-9e4e-e980a92c6815)
multiple user cards:
![image](https://github.com/user-attachments/assets/a28498f6-6e06-4258-bdef-bc6b1b925859)
